### PR TITLE
Add supplier portal page

### DIFF
--- a/index.md
+++ b/index.md
@@ -23,6 +23,8 @@ The billing address for each order will reference the API account information as
 
 [download our swagger.json]
 
+You can also preview planned features for our upcoming [supplier portal](supplier-portal.md).
+
 ----
 
 [download our swagger.json]: https://shopjimmy.github.io/partner-api/swagger.json

--- a/supplier-portal.md
+++ b/supplier-portal.md
@@ -1,0 +1,13 @@
+---
+title: Supplier Portal
+layout: default
+---
+
+Planned features for the supplier portal include:
+
+- **Authentication** so suppliers can securely access their data.
+- **Dashboard metrics** to provide insight into order and return trends.
+- **Payout estimates** showing upcoming payment information.
+- **Returns reporting** for easy tracking of product returns.
+
+More details will be documented as development progresses.


### PR DESCRIPTION
## Summary
- document the planned supplier portal features
- link the new page from the index

## Testing
- `bundle install` *(fails: Could not fetch specs due to no route to host)*