### PR TITLE
Add markdownlint and swagger validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,17 +6,36 @@ on:
   pull_request:
 
 jobs:
+  markdownlint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Run markdownlint
+        run: npx markdownlint "**/*.md"
+
+  swagger-validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Validate swagger.json
+        run: npx swagger-cli validate swagger.json
+
   # Build job
   build:
     runs-on: ubuntu-latest
+    needs:
+      - markdownlint
+      - swagger-validate
     steps:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.3' # Not needed with a .ruby-version file
-          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
-          cache-version: 0 # Increment this number if you need to re-download cached gems
+          ruby-version: '3.3'
+          bundler-cache: true
+          cache-version: 0
       - name: Build with Jekyll
         run: bundle exec jekyll build

--- a/README.md
+++ b/README.md
@@ -85,6 +85,15 @@ Assuming [Jekyll] and [Bundler] are installed on your computer:
 
     The built site is stored in the directory `_site`.
 
+## Running checks locally
+
+You can lint Markdown files and validate the API specification with Node.js tools:
+
+```bash
+npx markdownlint "**/*.md"
+npx swagger-cli validate swagger.json
+```
+
 ## Publishing your built site on a different platform
 
 Just upload all the files in the directory `_site`.


### PR DESCRIPTION
## Summary
- run markdownlint in CI
- run swagger.json validation in CI
- explain how to run checks locally

## Testing
- `npx markdownlint '**/*.md'` *(fails: EHOSTUNREACH)*
- `npx swagger-cli validate swagger.json` *(fails: EHOSTUNREACH)*