### PR TITLE
Add partner program homepage

### DIFF
--- a/api-briefing.md
+++ b/api-briefing.md
@@ -1,0 +1,30 @@
+---
+title: Briefing
+layout: default
+---
+
+## REST API Concept
+The production endpoint for the Partner API is currently **https://base.shopjimmy.com/api/partner/v1**
+
+To access the API, your application must be approved, and an account must be set up on our server. 
+Once approved, you will receive a client_id and client_secret, enabling you to begin development using our designated development endpoint.
+
+---
+### Shipping 
+You are required to provide access for our carrier accounts to ship using your services. 
+Each order request must include the corresponding shipping service name and carrier details.
+
+---
+### Billing
+All fulfilled orders will be invoiced electronically at a later time. 
+The billing address for each order will reference the API account information associated with your account.
+
+**Interact with our API using Swagger.io**
+
+[download our swagger.json]
+
+You can also preview planned features for our upcoming [supplier portal](supplier-portal.md).
+
+----
+
+[download our swagger.json]: https://shopjimmy.github.io/partner-api/swagger.json

--- a/index.md
+++ b/index.md
@@ -1,30 +1,70 @@
 ---
-title: Briefing
+title: Partner Programs
 layout: home
 ---
 
-## REST API Concept
-The production endpoint for the Partner API is currently **https://base.shopjimmy.com/api/partner/v1**
+### Introduction
 
-To access the API, your application must be approved, and an account must be set up on our server. 
-Once approved, you will receive a client_id and client_secret, enabling you to begin development using our designated development endpoint.
+ShopJimmy, a trailblazer in the secondary market parts industry since 2007, invites you to unlock new revenue streams and grow your business by selling your appliance parts to us. With over $350 million in parts sold and expanding inventory needs, we offer various programs tailored to maximize your returns and streamline your sales process.
 
----
-### Shipping 
-You are required to provide access for our carrier accounts to ship using your services. 
-Each order request must include the corresponding shipping service name and carrier details.
+![Placeholder](https://www.publicdomainpictures.net/pictures/130000/velka/red-box-background.jpg)
 
----
-### Billing
-All fulfilled orders will be invoiced electronically at a later time. 
-The billing address for each order will reference the API account information associated with your account.
+### Why Partner with ShopJimmy?
 
-**Interact with our API using Swagger.io**
+- Nearly two decades of leadership in supplying parts for a wide range of products.
+- Integration with major warranty companies, marketplaces, and service portals.
+- From teardowns to consignment, we have a solution for every need.
 
-[download our swagger.json]
+### Our Purchase Programs
 
-You can also preview planned features for our upcoming [supplier portal](supplier-portal.md).
+1. **Head Program:** We buy parts requiring further disassembly at $3.00/lb, covering transportation costs. Ideal for Washers and Dryers heads needing extra work.
 
-----
+   ![Placeholder](https://www.publicdomainpictures.net/pictures/130000/velka/red-box-background.jpg)
 
-[download our swagger.json]: https://shopjimmy.github.io/partner-api/swagger.json
+2. **Individual Boards and Parts:** For safely stackable parts, we offer $10.00/lb, including transportation. It’s not pretty, but it’s very effective.
+
+   ![Placeholder](https://www.publicdomainpictures.net/pictures/130000/velka/red-box-background.jpg)
+
+3. **CRATE Program:** "Comprehensive Recovery and Transportation Equipment" – We provide crates at $250 each, including all shipping costs, and pay you based on product type and weight upon inventory completion.
+
+   Size: 48" x 40" x 45"
+
+   Minimum order quantity: 4
+
+   ![Placeholder](https://www.publicdomainpictures.net/pictures/130000/velka/red-box-background.jpg)
+
+4. **Consignment Program:** Elevate your returns with our premium consignment service. ShopJimmy covers all aspects, including shipping, inventory management, sales, customer support, and returns handling. Enjoy a generous 30% return on your items after market fees are deducted. Although this option involves a longer timeframe for cash flow realization, businesses often experience a substantial increase in recovery, achieving $20+/lb. over the course of time. This program is designed to maximize your returns with minimal effort on your part, offering a strategic avenue for enhancing the profitability of your inventory.
+
+   ![Placeholder](https://www.publicdomainpictures.net/pictures/130000/velka/red-box-background.jpg)
+
+5. **DropZone by ShopJimmy:** Our revolutionary platform designed for ease, flexibility, and integration, enabling you to manage and expand your online sales effortlessly. This solution is best suited for expensive or heavy equipment.
+
+   ![Placeholder](https://www.publicdomainpictures.net/pictures/130000/velka/red-box-background.jpg)
+
+   DropZone (DZ) is a pioneering platform enabling seamless sales channel integration for businesses eager to expand online. It's designed with flexibility, ease of use, and efficiency in mind, providing:
+
+   - **Cloud-based or standalone server options**
+   - **Simple inventory linking with minimal coding**
+   - **Efficient order management and carrier integration**
+   - **Android app for large operations**
+   - **Flexible pricing strategies to maximize sales**
+
+   #### Benefits of Joining DropZone
+
+   - **First 6 Months Free:** Experience the operational benefits and sales growth potential with no upfront investment.
+   - **Affordable Subscription:** After the trial, a cost-effective $99/month/user subscription model.
+   - **Streamlined Payouts:** Reliable monthly payments for your sold items, with transparent return policies.
+
+### Conclusion
+
+Partnering with ShopJimmy or leveraging DropZone offers a unique opportunity to grow your business in the secondary parts market. With our support, you can easily manage inventory, expand your market reach, and increase profitability.
+
+To begin selling parts to us, explore our consignment program, or discover how DropZone can elevate your business, reach out to Jimmy Vosika, our Director of Partology.
+
+- **Email:** jimmy@shopjimmy.com
+- **WhatsApp:** 612-961-0224
+
+![Placeholder](https://www.publicdomainpictures.net/pictures/130000/velka/red-box-background.jpg)
+
+**Join us today and transform your business model with ShopJimmy.**
+


### PR DESCRIPTION
## Summary
- add marketing homepage with consignment and purchase program details
- keep existing API briefing page under `api-briefing.md`

## Testing
- `npx markdownlint "**/*.md"`
- `npx swagger-cli validate swagger.json`

The README includes instructions on running `bundle exec jekyll serve` to preview the site.