### PR TITLE
Add setup script for dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,13 @@ Assuming [Jekyll] and [Bundler] are installed on your computer:
 
 ## Running checks locally
 
-You can lint Markdown files and validate the API specification with Node.js tools:
+Before running the lint or validation commands, install the required dependencies:
+
+```bash
+./setup.sh
+```
+
+Then you can lint Markdown files and validate the API specification with Node.js tools:
 
 ```bash
 npx markdownlint "**/*.md"

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -e
+if ! command -v node >/dev/null; then
+    sudo apt-get update
+    sudo apt-get install -y nodejs npm
+fi
+gem install bundler
+bundle install


### PR DESCRIPTION
## Summary
- add `setup.sh` for Node and Ruby dependencies
- document using `./setup.sh` before running `npx` commands

## Testing
- `npx markdownlint "**/*.md"` *(fails: EHOSTUNREACH)*
- `npx swagger-cli validate swagger.json` *(fails: EHOSTUNREACH)*